### PR TITLE
add Detach

### DIFF
--- a/src/AssemblerManager.cpp
+++ b/src/AssemblerManager.cpp
@@ -97,6 +97,24 @@ void AssemblerManager::partsButtonClicked(const std::string &_name, const Vector
         ERROR_STREAM(" robot create error from parts : " << _name);
     }
 }
+void AssemblerManager::detachSceneRobot(ra::RASceneParts *_scpt)
+{
+    DEBUG_STREAM(" detach parts : " << _scpt->name());
+    ra::RASceneRobot *scrb_ = _scpt->scene_robot();
+    ra::RoboasmRobotPtr rb_ = scrb_->robot();
+
+    ra::RoboasmPartsPtr pt_ = _scpt->parts();
+
+    ra::RoboasmRobotPtr newrb_ = rb_->detach(pt_);
+    if(!!newrb_) {
+        DEBUG_STREAM(" newrb");
+        // clone-info [TODO]
+        deleteRobot(scrb_);
+        addAssemblerItem(rb_);
+        DEBUG_STREAM(" add newrb");
+        addAssemblerItem(newrb_);
+    }
+}
 void AssemblerManager::addAssemblerItem(ra::RoboasmRobotPtr _rb, MappingPtr _info)
 {
     AssemblerItemPtr itm = AssemblerItem::createItem(_rb, this);

--- a/src/AssemblerManager.cpp
+++ b/src/AssemblerManager.cpp
@@ -428,7 +428,7 @@ void AssemblerManager::deleteRobot(ra::RASceneRobot *_rb)
     notifyUpdate();
     SceneView::instance()->sceneWidget()->viewAll();
 }
-void AssemblerManager::attachRobots(bool _just_align, int increment)
+void AssemblerManager::attachRobots(bool _swap_order, bool _just_align, int increment)
 {
     DEBUG_PRINT();
     if(!clickedPoint0 || !clickedPoint1) {
@@ -438,8 +438,8 @@ void AssemblerManager::attachRobots(bool _just_align, int increment)
 
     ra::RASceneConnectingPoint *cp0 = clickedPoint0;
     ra::RASceneConnectingPoint *cp1 = clickedPoint1;
-    if(cp1->scene_robot()->robot()->partsNum() >
-       cp0->scene_robot()->robot()->partsNum() ) { // swap 0 and 1
+    if(_swap_order && (cp1->scene_robot()->robot()->partsNum() >
+                       cp0->scene_robot()->robot()->partsNum() ) ) { // swap 0 and 1
         ra::RASceneConnectingPoint *tmp = cp0;
         cp0 = cp1; cp1 = tmp;
     }
@@ -618,6 +618,8 @@ bool AssemblerManager::onContextMenuRequest(SceneWidgetEvent* event)
     menu->addSeparator();
     menu->addItem("Attach")->sigTriggered().connect(
         [this](){ com_attach(); } );
+    menu->addItem("Attach Order")->sigTriggered().connect(
+        [this](){ com_attach_o(); } );
     menu->addItem("Undo")->sigTriggered().connect(
         [this](){ com_undo(); } );
     menu->addSeparator();

--- a/src/AssemblerManager.h
+++ b/src/AssemblerManager.h
@@ -52,12 +52,13 @@ public:
     }
     void deleteRobot(ra::RASceneRobot *_rb);
     void deleteAllRobots();
-    void attachRobots(bool _just_align = false, int _increment = 1);
+    void attachRobots(bool _swap_order = true, bool _just_align = false, int _increment = 1);
     void itemSelected(AssemblerItemPtr itm, bool on);
     void loadRoboasm(const std::string &_fname);
     void com_attach()  { attachRobots(); }
-    void com_align()   { attachRobots(true); }
-    void com_align_back()   { attachRobots(true, -1); }
+    void com_attach_o(){ attachRobots(false); }
+    void com_align()   { attachRobots(true, true); }
+    void com_align_back() { attachRobots(true, true, -1); }
     void com_unalign() { }
     void com_undo()    { }
     void com_save_model();

--- a/src/AssemblerManager.h
+++ b/src/AssemblerManager.h
@@ -51,6 +51,7 @@ public:
         return (it != srobot_set.end());
     }
     void deleteRobot(ra::RASceneRobot *_rb);
+    void detachSceneRobot(ra::RASceneParts *_scpt);
     void deleteAllRobots();
     void attachRobots(bool _swap_order = true, bool _just_align = false, int _increment = 1);
     void itemSelected(AssemblerItemPtr itm, bool on);

--- a/src/RobotAssembler.cpp
+++ b/src/RobotAssembler.cpp
@@ -652,6 +652,31 @@ bool RoboasmRobot::checkCorrectPoint(RoboasmCoordsPtr robot_or_parts,
     }
     return true;
 }
+RoboasmRobotPtr RoboasmRobot::detach(RoboasmPartsPtr _pt)
+{
+    partsPtrList lst;
+    allParts(lst);
+    auto it = std::find(lst.begin(), lst.end(), _pt);
+    if(it == lst.end()) return nullptr;
+    if(_pt->parent() == this) return nullptr;
+
+    // pt->parent (parts-point)
+    // pt->parent->parent (parent-point)
+    if( !(_pt->parent()) || !(_pt->parent()->parent()) ) return nullptr;
+
+    RoboasmCoordsPtr pt_p = _pt->parent()->parent()->isDirectDescendant(_pt->parent());
+    bool res = _pt->parent()->dissocFromParent();
+    if(!res) return nullptr;
+
+    res = _pt->dissocFromParent();
+    if(!res) return nullptr;
+    if(pt_p->hasDescendants()) return nullptr;
+
+    _pt->assoc(pt_p);
+
+    RoboasmRobotPtr ret = std::make_shared<RoboasmRobot>("divided_robot", _pt, settings);
+    return ret;
+}
 bool RoboasmRobot::checkAttachByName(RoboasmCoordsPtr robot_or_parts,
                                      const std::string &name_parts_point,
                                      const std::string &name_robot_point,

--- a/src/RobotAssembler.h
+++ b/src/RobotAssembler.h
@@ -358,9 +358,6 @@ public:
                 bool just_align = false);
     //this method destroy robot structure...
     bool changeRoot(RoboasmConnectingPointPtr _chld); // static method
-
-    // RoboasmRobotPtr detach(RoboasmPartsPtr _parts);
-    // RoboasmRobotPtr detach(RoboasmConnectiongPtr _parts);
     size_t partsNum() {
         partsPtrList lst;
         allParts(lst);
@@ -387,6 +384,9 @@ public:
     bool createRoboasm(RoboasmFile &_roboasm);
     bool writeConfig(AssembleConfig &_config);
     void connectedPoints(connectingPointPtrList &lst);
+    // RoboasmRobotPtr detach(RoboasmConnectiongPointPtr _cp);
+    RoboasmRobotPtr detach(RoboasmPartsPtr _pt);
+
 protected:
     SettingsPtr settings;
     friend RoboasmCoords;

--- a/src/RobotAssemblerHelper.cpp
+++ b/src/RobotAssemblerHelper.cpp
@@ -412,13 +412,18 @@ bool RASceneRobot::onContextMenuRequest(SceneWidgetEvent* event)
         std::string label1_ = "Save model : " + this->name();
         menu->addItem(label1_)->sigTriggered().connect(
             [this](){ manager->save_model(this); });
+        //
         menu->addSeparator();
-        std::string label2_ = "Delete This: " + this->name();
+        std::string label2_ = "Delete Robot: " + this->name();
         menu->addItem(label2_)->sigTriggered().connect(
             [this](){ manager->deleteRobot(this); });
+        //
         menu->addSeparator();
         std::string label3_ = "Select Parts : " + lastClickedParts->name();
         menu->addItem(label3_);
+        std::string label4_ = "Detach Parts : " + lastClickedParts->name();
+        menu->addItem(label4_)->sigTriggered().connect(
+            [this](){ manager->detachSceneRobot(lastClickedParts); });
     }
     if (!!lastClickedPoint) {
         menu->addSeparator();

--- a/src/RobotAssemblerHelper.h
+++ b/src/RobotAssemblerHelper.h
@@ -106,8 +106,6 @@ public:
     RASceneParts *searchParts(RoboasmPartsPtr _pt);
     RASceneConnectingPoint *searchConnectingPoint(RoboasmConnectingPointPtr _pt);
     bool mergeRobot(RASceneRobot *_rb);
-    // removeParts [TODO]
-
 #if 0
     void debug() {
         partsPtrList plst;

--- a/src/RobotAssemblerInfo.cpp
+++ b/src/RobotAssemblerInfo.cpp
@@ -35,9 +35,8 @@ MappingPtr ra::createInfo(ra::RoboasmRobotPtr _rb)
     MappingPtr rb_info = new Mapping();
     addToMapping(rb_info, "name", _rb->name());
     coordinates cds_ = *root_;
-    addToMapping(rb_info, "initial-coords", cds_);
+    addCoordsToMapping(rb_info, "initial-coords", cds_);
     ret->insert("robot-info", rb_info);
-
     MappingPtr pt_info = new Mapping();
     bool added = false;
     ra::partsPtrList lst;
@@ -140,7 +139,7 @@ MappingPtr ra::cnoidRAFile::historyToMap(MappingPtr _main)
                     // no config
             } else {
                 if(!(*it).connecting_offset.isInitial(1e-12)) {
-                    addToMapping(hitm, "connecting-offset", (*it).connecting_offset);
+                    addCoordsToMapping(hitm, "connecting-offset", (*it).connecting_offset);
                 }
             }
         } else {

--- a/src/ValueTreeUtil.h
+++ b/src/ValueTreeUtil.h
@@ -88,7 +88,7 @@ inline void addToMapping(Mapping *_mp, const std::string &_key, ValueNode *_tgt)
     }
     _mp->insert(_key, _tgt);
 }
-inline void addToMapping(Mapping *_mp, const std::string &_key, double a, Vector3 &_vec, double eps = 1e-12)
+inline void addToMapping(Mapping *_mp, const std::string &_key, double a, const Vector3 &_vec, double eps = 1e-12)
 {
     ValueNode *vn = _mp->find(_key);
     if(vn->isValid()) {
@@ -119,7 +119,7 @@ inline void addToMapping(Mapping *_mp, const std::string &_key, double a, Vector
     }
     _mp->insert(_key, lst);
 }
-inline void addToMapping(Mapping *_mp, const std::string &_key, Vector3 &_vec, double eps = 1e-12)
+inline void addToMapping(Mapping *_mp, const std::string &_key, const Vector3 &_vec, double eps = 1e-12)
 {
     ValueNode *vn = _mp->find(_key);
     if(vn->isValid()) {
@@ -145,7 +145,7 @@ inline void addToMapping(Mapping *_mp, const std::string &_key, Vector3 &_vec, d
     }
     _mp->insert(_key, lst);
 }
-inline void addToMapping(Mapping *_mp, const std::string &_key, Vector3f &_vec, double eps = 1e-12)
+inline void addToMapping(Mapping *_mp, const std::string &_key, const Vector3f &_vec, double eps = 1e-12)
 {
     ValueNode *vn = _mp->find(_key);
     if(vn->isValid()) {
@@ -208,7 +208,7 @@ inline void addToMapping(Mapping *_mp, const std::string &_key, bool _bl)
     }
     _mp->write(_key, _bl);
 }
-inline void addToMapping(Mapping *_mp, const std::string &_key, const coordinates &_cds)
+inline void addCoordsToMapping(Mapping *_mp, const std::string &_key, const coordinates &_cds)
 {
     if(_cds.isInitial()) return;
     ValueNode *vn = _mp->find(_key);


### PR DESCRIPTION
パーツを選択して、選んだパーツを分離できるようにしました。
また、コンテキストメニューでAttach Orderを選ぶと、コネクティングポイントの選択の順番が接続の親子関係を決めます。
（最初に選んだほうが親、後に選んだほうが子。 通常のAttachは、パーツが多いほうが親になる）